### PR TITLE
Fixed incorrect download links and file names in README.md and CLI.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
  <p align="center">
       <a href="https://repo1.maven.org/maven2/com/jayasuryat/mendable/"><img alt="Mendable at MavenCentral" src="https://staging.shields.io/maven-central/v/com.jayasuryat.mendable/mendable?style=for-the-badge&color=%2332cc57"/></a>
-    <a href="https://github.com/jayasuryat/mendable/releases/download/v0.7.0/mendable-app.jar"><img alt="Download Mendable" src="https://img.shields.io/badge/Mendable.jar-0.7.0-%2306090E?style=for-the-badge&logo=jetpackcompose&color=%2332cc57"/></a>
+    <a href="https://github.com/jayasuryat/mendable/releases/download/v0.7.0/mendable.jar"><img alt="Download Mendable" src="https://img.shields.io/badge/Mendable.jar-0.7.0-%2306090E?style=for-the-badge&logo=jetpackcompose&color=%2332cc57"/></a>
   </p>
 
   <p align="center">
@@ -61,7 +61,7 @@ non-problematic ones. It consolidates reports from multiple `modules` into a sin
 
 #### 3.1 Download Mendable CLI tool
 
-<a href="https://github.com/jayasuryat/mendable/releases/download/v0.7.0/mendable-app.jar"><img alt="Download Mendable" src="https://img.shields.io/badge/Mendable.jar-0.7.0-%2306090E?style=for-the-badge&logo=jetpackcompose&color=%2332cc57"/></a>
+<a href="https://github.com/jayasuryat/mendable/releases/download/v0.7.0/mendable.jar"><img alt="Download Mendable" src="https://img.shields.io/badge/Mendable.jar-0.7.0-%2306090E?style=for-the-badge&logo=jetpackcompose&color=%2332cc57"/></a>
 
 #### 3.2 Or, download Mendable Maven Artifacts
 

--- a/docs/howto/Cli.md
+++ b/docs/howto/Cli.md
@@ -20,13 +20,13 @@ and `generate` a beautiful `report` for you.
 
 ### ✨ Generate report with a single command ✨
 
-[Download](https://github.com/jayasuryat/mendable/releases/download/v0.7.0/mendable-app.jar) and place the `jar` file in
+[Download](https://github.com/jayasuryat/mendable/releases/download/v0.7.0/mendable.jar) and place the `jar` file in
 the
 same folder which contains all the generated Compose compiler metrics (should be `YourProject/build/compose_metrics`).
 And then execute the `jar` file with the following `command`.
 
 ```
-java -jar mendable-app.jar
+java -jar mendable.jar
 ```
 
 After executing this `command` there should be `index.html` file generated in the same folder, which will contain the


### PR DESCRIPTION
Fixed incorrect download links and file names in README.md and CLI.md
Resolves https://github.com/jayasuryat/mendable/issues/47